### PR TITLE
Move to NGC PyTorch 25.09 and drop apex so the build works on arm64

### DIFF
--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -1,123 +1,118 @@
 specVersion: v2
 specMinorVersion: 2
 meta:
-  name: llama3-finetune
-  image: project-llama3-finetune
-  description: An example project for finetuning a Llama3 model
-  labels: []
-  createdOn: "2024-07-09T22:56:06Z"
-  defaultBranch: main
+    name: llama3-finetune
+    image: project-llama3-finetune
+    description: An example project for finetuning a Llama3 model
+    labels: []
+    createdOn: "2024-07-09T22:56:06Z"
+    defaultBranch: main
 layout:
-- path: code/
-  type: code
-  storage: git
-- path: models/
-  type: models
-  storage: gitlfs
-- path: data/
-  type: data
-  storage: gitlfs
-- path: data/scratch/
-  type: data
-  storage: gitignore
+    - path: code/
+      type: code
+      storage: git
+    - path: models/
+      type: models
+      storage: gitlfs
+    - path: data/
+      type: data
+      storage: gitlfs
+    - path: data/scratch/
+      type: data
+      storage: gitignore
 environment:
-  base:
-    registry: nvcr.io
-    image: nvidia/ai-workbench/pytorch:1.0.2
-    build_timestamp: "20231102150513"
-    name: PyTorch
-    supported_architectures: []
-    cuda_version: "12.2"
-    description: A Pytorch 2.1 Base with CUDA 12.2
-    entrypoint_script: ""
-    labels:
-    - cuda12.2
-    - pytorch2.1
-    apps:
-    - name: jupyterlab
-      type: jupyterlab
-      class: webapp
-      start_command: jupyter lab --allow-root --port 8888 --ip 0.0.0.0 --no-browser
-        --NotebookApp.base_url=\$PROXY_PREFIX --NotebookApp.default_url=/lab --NotebookApp.allow_origin='*'
-      health_check_command: '[ \$(echo url=\$(jupyter lab list | head -n 2 | tail
-        -n 1 | cut -f1 -d'' '' | grep -v ''Currently'' | sed "s@/?@/lab?@g") | curl
-        -o /dev/null -s -w ''%{http_code}'' --config -) == ''200'' ]'
-      stop_command: jupyter lab stop 8888
-      user_msg: ""
-      logfile_path: ""
-      timeout_seconds: 60
-      icon_url: ""
-      webapp_options:
-        autolaunch: true
-        port: "8888"
-        proxy:
-          trim_prefix: false
-        url_command: jupyter lab list | head -n 2 | tail -n 1 | cut -f1 -d' ' | grep
-          -v 'Currently'
-    - name: tensorboard
-      type: tensorboard
-      class: webapp
-      start_command: tensorboard --logdir \$TENSORBOARD_LOGS_DIRECTORY --path_prefix=\$PROXY_PREFIX
-        --bind_all
-      health_check_command: '[ \$(curl -o /dev/null -s -w ''%{http_code}'' http://localhost:\$TENSORBOARD_PORT\$PROXY_PREFIX/)
-        == ''200'' ]'
-      stop_command: pkill tensorboard
-      user_msg: ""
-      logfile_path: ""
-      timeout_seconds: 60
-      icon_url: ""
-      webapp_options:
-        autolaunch: true
-        port: "6006"
-        proxy:
-          trim_prefix: false
-        url: http://localhost:6006
-    programming_languages:
-    - python3
-    icon_url: ""
-    image_version: 1.0.2
-    os: linux
-    os_distro: ubuntu
-    os_distro_release: "22.04"
-    schema_version: v2
-    user_info:
-      uid: ""
-      gid: ""
-      username: ""
-    package_managers:
-    - name: apt
-      binary_path: /usr/bin/apt
-      installed_packages:
-      - curl
-      - git
-      - git-lfs
-      - vim
-    - name: pip
-      binary_path: /usr/local/bin/pip
-      installed_packages:
-      - jupyterlab==4.0.7
-    package_manager_environment:
-      name: ""
-      target: ""
+    base:
+        registry: nvcr.io
+        image: nvidia/pytorch:25.09-py3
+        build_timestamp: "20231102150513"
+        name: PyTorch
+        supported_architectures: []
+        cuda_version: "13.0"
+        description: NGC PyTorch 2.9 with CUDA 13.0 (multi-arch, supports arm64/Blackwell)
+        entrypoint_script: ""
+        labels:
+            - cuda13.0
+            - pytorch2.9
+        apps:
+            - name: jupyterlab
+              type: jupyterlab
+              class: webapp
+              start_command: jupyter lab --allow-root --port 8888 --ip 0.0.0.0 --no-browser --NotebookApp.base_url=\$PROXY_PREFIX --NotebookApp.default_url=/lab --NotebookApp.allow_origin='*'
+              health_check_command: '[ \$(echo url=\$(jupyter lab list | head -n 2 | tail -n 1 | cut -f1 -d'' '' | grep -v ''Currently'' | sed "s@/?@/lab?@g") | curl -o /dev/null -s -w ''%{http_code}'' --config -) == ''200'' ]'
+              stop_command: jupyter lab stop 8888
+              user_msg: ""
+              logfile_path: ""
+              timeout_seconds: 60
+              icon_url: ""
+              webapp_options:
+                autolaunch: true
+                port: "8888"
+                proxy:
+                    trim_prefix: false
+                url_command: jupyter lab list | head -n 2 | tail -n 1 | cut -f1 -d' ' | grep -v 'Currently'
+            - name: tensorboard
+              type: tensorboard
+              class: webapp
+              start_command: tensorboard --logdir \$TENSORBOARD_LOGS_DIRECTORY --path_prefix=\$PROXY_PREFIX --bind_all
+              health_check_command: '[ \$(curl -o /dev/null -s -w ''%{http_code}'' http://localhost:\$TENSORBOARD_PORT\$PROXY_PREFIX/) == ''200'' ]'
+              stop_command: pkill tensorboard
+              user_msg: ""
+              logfile_path: ""
+              timeout_seconds: 60
+              icon_url: ""
+              webapp_options:
+                autolaunch: true
+                port: "6006"
+                proxy:
+                    trim_prefix: false
+                url: http://localhost:6006
+        programming_languages:
+            - python3
+        icon_url: ""
+        image_version: 1.0.2
+        os: linux
+        os_distro: ubuntu
+        os_distro_release: "22.04"
+        schema_version: v2
+        user_info:
+            uid: ""
+            gid: ""
+            username: ""
+        package_managers:
+            - name: apt
+              binary_path: /usr/bin/apt
+              installed_packages:
+                - curl
+                - git
+                - git-lfs
+                - vim
+            - name: pip
+              binary_path: /usr/local/bin/pip
+              installed_packages:
+                - jupyterlab==4.0.7
+        package_manager_environment:
+            name: ""
+            target: ""
+    compose_file_path: ""
 execution:
-  apps: []
-  resources:
-    gpu:
-      requested: 1
-    sharedMemoryMB: 1024
-  secrets:
-  - variable: HF_KEY
-    description: Hugging Face Hub Token
-  mounts:
-  - type: project
-    target: /project/
-    description: Project directory
-    options: rw
-  - type: volume
-    target: /data/tensorboard/logs/
-    description: Tensorboard Log Files
-    options: volumeName=tensorboard-logs-volume
-  - type: host
-    target: /project/models/
-    description: Where to save the finetuned Llama3 model on the underlying *host* machine, ie. for home path, enter /home/[user] or /mnt/C/Users/[user] (Windows)
-    options: ""
+    apps: []
+    resources:
+        gpu:
+            requested: 1
+        sharedMemoryMB: 1024
+    secrets:
+        - variable: HF_KEY
+          description: Hugging Face Hub Token
+    mounts:
+        - type: project
+          target: /project/
+          description: Project directory
+          options: rw
+        - type: volume
+          target: /data/tensorboard/logs/
+          description: Tensorboard Log Files
+          options: volumeName=tensorboard-logs-volume
+        - type: host
+          target: /project/models/
+          description: Where to save the finetuned Llama3 model on the underlying *host* machine, ie. for home path, enter /home/[user] or /mnt/C/Users/[user] (Windows)
+          options: ""

--- a/postBuild.bash
+++ b/postBuild.bash
@@ -3,3 +3,8 @@
 # after all system packages and programming language specific package have been installed.
 #
 # Note: This file may be removed if you don't need to use it
+
+# The NGC PyTorch base image ships a newer apex without `apex.amp`, which
+# transformers 4.41 tries to import (`from apex import amp`) and then fails on.
+# torch has native AMP, so apex is not needed here.
+sudo -E pip uninstall -y apex || true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 jupyterlab>3.0
 datasets==2.19.1
-bitsandbytes==0.43.1
+bitsandbytes==0.47.0
 transformers==4.41.1
 peft==0.11.1
 accelerate==0.30.1
 trl==0.8.6
 ipywidgets==8.1.3
-wandb==0.17.0
+wandb==0.22.3


### PR DESCRIPTION
### Issue

* The base image `nvidia/ai-workbench/pytorch:1.0.2` has no arm64 build, so the project cannot be built on Grace Blackwell hosts such as DGX Spark or GB10.
* `transformers==4.41.1` does `from apex import amp`. The NGC PyTorch images ship a newer apex that no longer exposes `apex.amp`, so the import fails.
* `bitsandbytes==0.43.1` is not installable from PyPI, which already breaks the build. This is the same failure reported in #5 and #6.

### Change

* Move the base image to `nvidia/pytorch:25.09-py3`, which is multi-arch and covers arm64. CUDA moves to 13.0 and PyTorch to 2.9.
* Bump `bitsandbytes` to 0.47.0 and `wandb` to 0.22.3. The other pins are deliberately left alone.
* Uninstall apex in `postBuild.bash`, since torch provides native AMP and apex is not needed here.

### Notes

* The `.project/spec.yaml` diff looks large because Workbench reindents the file from 2 spaces to 4 and unwraps the long command strings. Ignoring whitespace the real change is 11 insertions and 16 deletions: the base image, the CUDA version, and the two labels.
* This overlaps with open PR #6, which also targets the bitsandbytes failure. Happy to rebase on top of that or to close this if #6 lands first.
* Not yet validated end to end. It fixes the build and the apex import. The notebooks may still need attention for other API drift, for example the `dataset_text_field` problem in #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
